### PR TITLE
Unmask SMC IRQ after muxed irqs are handled.

### DIFF
--- a/arch/arm/mach-mmp/ts4700_mux_irq.c
+++ b/arch/arm/mach-mmp/ts4700_mux_irq.c
@@ -62,6 +62,8 @@ static void mux_irq_handler(unsigned int irq, struct irq_desc *desc)
          if(fpga_irq_reg & bit)            
             generic_handle_irq(MIN_FPGA_IRQ + n);         
       }
+      
+   ICU_INT_CONF(0xfc) |= 1 ; /* Unmask SMC_IRQ */
      
 }
 


### PR DESCRIPTION
If SMC IRQ isn't unmasked, the FPGA handler can stop being called after a random time if the muxed handlers are performing any "substantial" work (and as such all the muxed handlers are never called from this point on).
